### PR TITLE
Changed underlying int structure to FatRat to completely avoid loss of precision

### DIFF
--- a/t/00-use.rakutest
+++ b/t/00-use.rakutest
@@ -27,5 +27,11 @@ ok "$m3" eq '1.00 INR', "gist/Str properly produces nice output, produced $m3";
 ok "$m5" eq '$50.00 CAD', "postfix constructor creates money";
 
 ok Money.new('$1.00 USD') eqv Money.new(1.00, 'USD'), "regex doesn't properly parse decimal values $(Money.new('$1.00 USD'))";
+ok money('$1.00 USD') eqv Money.new(1.00, 'USD'), "regex doesn't properly parse decimal values $(Money.new('$1.00 USD'))";
+
+ok Money.new('$1.00 USD') == Money.new(1.00, 'USD'), "`==` failed";
+
+ok (1.0USD).is-positive, "is-positive works";
+ok (-1.0USD).is-negative, "is-negative works";
 
 done-testing;


### PR DESCRIPTION
Using `Rat` instead of `FatRat` was an oversight on my end, probably should keep it as precise as possible. Still much better than storing the cent value because it allows for cases of currencies that may be divided beyond cents.